### PR TITLE
added: make it clear that a header is clickable on hover, closes #63

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -369,19 +369,9 @@ table tr th, table tr td {
     padding: 0;
 }
 
-.badge:link, .badge:visited {
-    border-radius: 4px;
-    padding: 1px 3px;
-    color: white;
-    font-size: 12px;
-}
-
-.review {
-    background: orange;
-}
-
-.pending {
-    background: red;
+.clickable:hover {
+    cursor: pointer;
+    text-decoration: underline;
 }
 
 /* Syntax highlighting styles */

--- a/js/script.js
+++ b/js/script.js
@@ -60,6 +60,8 @@ function getMenuElement(headingEl) {
  */
 function setHeaderListeners() {
     var headers = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
+
+    addClickableClass(headers);
     addListeners(headers, 'click', headerClickHandler);
 }
 
@@ -84,4 +86,17 @@ function headerClickHandler(event) {
 function setHash(hash) {
     hash = (hash && hash.indexOf('#') !== 0) ? '#' + hash : hash;
     history.pushState({}, '', hash);
+}
+
+/**
+ * Adds class "clickable" to all elements in NodeList.
+ * 
+ * @param {NodeList} headers list of HTML Elements
+ */
+function addClickableClass(elements) {
+    if (elements && elements.length) {
+        for (var i = 0; i < elements.length; i++) {
+            elements[i].classList.add('clickable');
+        }
+    }
 }


### PR DESCRIPTION
This uses `text-decoration:underline` and a link `cursor:pointer` upon `:hover`