### PR TITLE
added jr:requiredMsg, closes #31

### DIFF
--- a/_sections/30-bindings.md
+++ b/_sections/30-bindings.md
@@ -41,6 +41,7 @@ The following attributes are supported on `<bind>` nodes. Only the nodeset attri
 | `constraint`| Specifies acceptable answers for the specified prompt with an XPath expression. Will only be evaluated when the node is non-empty.
 | `calculate` | Calculates a node value with an XPath expression.
 | `saveIncomplete` | Specifies whether to automatically save the draft record when the user reaches this question, options `true()` and `false()`. Considered false() if omitted.
+| `jr:requiredMsg` | Specifies the custom message to be displayed when the `required` is violated. Attribute in "http://openrosa.org/javarosa" namespace.
 | `jr:constraintMsg` | The message that will be displayed if the specified constraint is violated.
 | `jr:preload`| Preloaders for predefined meta data. See [preloaders](#preloaders---metadata).
 | `jr:preloadParams` | Parameters used by `jr:preload`. See [preloaders](#preloaders---metadata).


### PR DESCRIPTION
the wording matches the updated wording of jr:constraintMsg in PR #65 