### PR TITLE
Added section on external XML instances, closes #50

### DIFF
--- a/_sections/20-instance.md
+++ b/_sections/20-instance.md
@@ -113,4 +113,10 @@ A secondary instance should get a unique `id` attribute on the `<instance>` node
 
 ### Secondary Instances - External
 
-[Proposal pending](https://github.com/opendatakit/odk-xform-spec/issues/50).
+The previous section discussed secondary instances with static read-only data that is present in the XForm document itself. Another type of secondary instances presents read-only data from an _external_ source. The external source can be static or dynamic and is specified using the additional `src` attribute with a URI value on an empty `<instance>` node. Querying an external instance is done in exactly the same way as for an [internal secondary instance](#secondary-instances---internal).
+
+{% highlight xml %}
+<instance id="countries" src="jr://file/country-data.xml"/>
+{% endhighlight %}
+
+See the [section on URIs](#uris) for acceptable URI formats that refer to an external secondary instance.

--- a/_sections/90-uri.md
+++ b/_sections/90-uri.md
@@ -1,5 +1,5 @@
 ---
-title: URI Support
+title: URIs
 ---
 
 Throughout the XForm format URIs are used to refer to resources outside of the XForm itself. The `jr` "protocol" is used to indicate the resource is available in a sandboxed environment the client is aware of. At the moment only binary endpoints are supported.
@@ -13,3 +13,4 @@ Binary endpoints point to files. The following are supported:
 | `jr://images/path/to/file.png`             | points to an image resource in the sandboxed environment
 | `jr://audio/path/to/file.mp3`              | points to an audio resource in the sandboxed environment
 | `jr://video/path/to/file.mp4`              | points to a video resource in the sandboxed environment
+| `jr://file/path/to/file.xml`               | points to an XML resource in the sandboxed enviroment.


### PR DESCRIPTION
> "That's one small step for spec, one giant leap for ecosystem."