### PR TITLE
Add XPath 3 (and 2) abs function.

### DIFF
--- a/_sections/30-bindings.md
+++ b/_sections/30-bindings.md
@@ -132,6 +132,7 @@ A subset of [XPath 1.0 functions](http://www.w3.org/TR/xpath/#corelib), some fun
 | `pow(number value, number power)`			| As in [XPath 3.0](http://www.w3.org/TR/xpath-functions-30/#func-math-pow).
 | `log(number arg)`                         | As in [XPath 3.0](http://www.w3.org/TR/xpath-functions-30/#func-math-log).
 | `log10(number arg)`                       | As in [XPath 3.0](http://www.w3.org/TR/xpath-functions-30/#func-math-log10).
+| `abs(number arg)`                         | As in [XPath 3.0](https://www.w3.org/TR/xpath-functions-30/#func-abs).
 | `sin(number arg)`							| As in [XPath 3.0](https://www.w3.org/TR/xpath-functions-30/#func-math-sin).
 | `cos(number arg)` 						| As in [XPath 3.0](https://www.w3.org/TR/xpath-functions-30/#func-math-cos).
 | `tan(number arg)` 						| As in [XPath 3.0](https://www.w3.org/TR/xpath-functions-30/#func-math-tan).


### PR DESCRIPTION
This is one that has been desired in Collect for some time - opendatakit/javarosa#4 - and that will be added in the next JavaRosa release (not slated to happen for some time yet). It's possible to get this behavior with stock XPath 1.0 but this is very convenient.

I decided to put it with other XPath 3.0 functions even though this one is also in XPath 2.0. After log10 and before the trig functions was the most logical placement I could come up with.