### PR TITLE
Describe compact representation

### DIFF
--- a/_sections/20-instance.md
+++ b/_sections/20-instance.md
@@ -31,6 +31,9 @@ Nodes inside a primary instance can contain attributes. The client application n
 |---------------|------------
 | `id`          | on the childnode of the primary instance: This is the unique ID at which the form is identified by the server that publishes the Form and receives data submissions. For more information see [this Form List Specification](https://bitbucket.org/javarosa/javarosa/wiki/FormListAPI). \[required\]
 | `orx:version` | on the childnode of the primary instance in the _http://openrosa.org/xforms/_ namespace: Form version which can contain any string value. Like [meta nodes](#metadata) this information is used as a _processing cue_ for the server receiving the submission.
+| `odk:prefix` | on the childnode of the primary instance in the _http://opendatakit.org/xforms_ namespace: optional string prefix which is included at the beginning of the [compact representation](#compact-record-representation-(for-sms))
+| `odk:delimiter` | on the childnode of the primary instance in the _http://opendatakit.org/xforms_ namespace: optional string delimiter which is used to separate prefix, tags and values in the [compact representation](#compact-record-representation-(for-sms))
+| `odk:tag` | on a question node (grandchild of the primary instance) in the _http://opendatakit.org/xforms_ namespace: optional string tag which is used to identify nodes that should be part of the [compact representation](#compact-record-representation-(for-sms))
 | `jr:template` | on any repeat group node in the _http://openrosa.org/javarosa namespace_: This serves to define a default template for repeats and is useful if any of the leaf nodes inside a repeat contains a default value. It is not transmitted in the record and only affects the behavior of the form engine. For more details, see the [repeats](#repeats) section.
 
 The primary instance also includes a special type of nodes for metadata inside the `<meta>` block. See the [Metadata](#metadata) section

--- a/_sections/93-compact-representation.md
+++ b/_sections/93-compact-representation.md
@@ -1,0 +1,61 @@
+---
+title: Compact Record Representation (for SMS) 
+---
+ODK XForms records are generally represented as XML using the structure of the [primary instance](primary-instance). It is also possible to define how a record can be represented more compactly, usually for SMS submission. 
+
+For this representation:
+- The value of the `prefix` attribute on the primary instance's single child is included at the beginning of every record.
+
+- Questions that have a `tag` attribute are represented as the `tag` value followed by the element's value. Questions without a `tag` attribute are omitted.
+
+- The value of the `delimiter` attribute on the primary instance's single child is used to separate components of the compact representation (prefix, tags, values). Defaults to a single space (` `) if not explicitly specified.
+
+Given the following ODK XForm definition:
+
+{% highlight xml %}
+<instance>
+    <household id="household_survey" orx:version="2018061801" prefix="hh" delimiter="|">
+    	<meta>
+          <instanceID tag="id" />
+        </meta>
+        <person>
+            <firstname tag="fn" />
+            <lastname tag="ln" />
+            <age>10</age>
+        </person>
+    </household>
+</instance>
+{% endhighlight %}
+
+Full records might look like:
+
+{% highlight xml %}
+<household id="household_survey">
+	<meta>
+		<instanceID>uuid:82724cc5-df6f-46bf-86d5-26683ae35d5b</instanceID>
+	</meta>
+	<firstname></firstname>
+	<lastname>Bar</lastname>
+	<age>10</age>
+</household>
+{% endhighlight %}
+
+{% highlight xml %}
+<household id="household_survey">
+	<meta>
+		<instanceID>uuid:82724cc5-df6f-46bf-86d5-26683ae35d5b</instanceID>
+	</meta>
+	<firstname>Mary Kate</firstname>
+	<lastname>Doe</lastname>
+	<age>15</age>
+</household>
+{% endhighlight %}
+
+The compact representations of those records would be:
+`hh|fn||ln|Bar`
+
+`hh|fn|Mary Kate|ln|Doe`
+
+If the delimiter is included in one of the question values, it will be prepended by a slash. For example, the first name `"Mary|Kate"` would be represented as `"Mary\|Kate"`
+
+As in the regular representation, nodes that are not relevant are not included in the compact representation, even if the `tag` attribute is defined.

--- a/_sections/93-compact-representation.md
+++ b/_sections/93-compact-representation.md
@@ -14,13 +14,13 @@ Given the following ODK XForm definition:
 
 {% highlight xml %}
 <instance>
-    <household id="household_survey" orx:version="2018061801" prefix="hh" delimiter="|">
+    <household id="household_survey" orx:version="2018061801" odk:prefix="hh" odk:delimiter="|">
     	<meta>
-          <instanceID tag="id" />
+          <instanceID odk:tag="id" />
         </meta>
         <person>
-            <firstname tag="fn" />
-            <lastname tag="ln" />
+            <firstname odk:tag="fn" />
+            <lastname odk:tag="ln" />
             <age>10</age>
         </person>
     </household>
@@ -30,23 +30,22 @@ Given the following ODK XForm definition:
 Full records might look like:
 
 {% highlight xml %}
-<household id="household_survey">
+<household id="household_survey" orx:version="2018061801" odk:prefix="hh" odk:delimiter="|">
 	<meta>
 		<instanceID>uuid:82724cc5-df6f-46bf-86d5-26683ae35d5b</instanceID>
 	</meta>
-	<firstname></firstname>
-	<lastname>Bar</lastname>
+	<lastname odk:tag="ln">Bar</lastname>
 	<age>10</age>
 </household>
 {% endhighlight %}
 
 {% highlight xml %}
-<household id="household_survey">
+<household id="household_survey" orx:version="2018061801" odk:prefix="hh" odk:delimiter="|">
 	<meta>
 		<instanceID>uuid:82724cc5-df6f-46bf-86d5-26683ae35d5b</instanceID>
 	</meta>
-	<firstname>Mary Kate</firstname>
-	<lastname>Doe</lastname>
+	<firstname odk:tag="fn">Mary Kate</firstname>
+	<lastname odk:tag="ln">Doe</lastname>
 	<age>15</age>
 </household>
 {% endhighlight %}


### PR DESCRIPTION
Closes #188 

This will require some wordsmithing and some references from other sections of the document (e.g. introducing `prefix` and `delimiter` along with `id` and `orx:version`) but I wanted to get the basics as they stand out here so we can make sure the spec itself is ok.

@ukanga @MartijnR if there is already something like this in use in the ecosystem, it would be very helpful to understand whether it's compatible with what we have here.

@jd-alexander @yanokwa please make sure I have consolidated the various ideas and implementations correctly and that nothing is missing.

One big question mark for me is namespaces. The original intent of https://bitbucket.org/javarosa/javarosa/wiki/SMSSendingAPI seemed to be to introduce `tag`, `prefix` and `delimiter` in a new `http://openrosa.org/smsdata` namespace but in practice this was not enforced. My feeling is that this is not worth introducing a new namespace for and that `https://opendatakit.org/xforms` would be appropriate.