### PR TITLE
Document odk-instance-first-load

### DIFF
--- a/_sections/30-bindings.md
+++ b/_sections/30-bindings.md
@@ -241,15 +241,15 @@ Supported preload attribute combinations are:
 
 | jr:preload    | jr:preloadParams  | value           		| event
 |---------------|-------------------|-----------------------|-------------
-| uid           |                   | see `instanceID` 		| [xforms-ready](https://www.w3.org/TR/xforms/#evt-ready) if no existing value
-| timestamp     | start             | see `timeEnd` 		| [xforms-ready](https://www.w3.org/TR/xforms/#evt-ready) if no existing value
+| uid           |                   | see `instanceID` 		| [odk-instance-first-load](#event:odk-instance-first-load)
+| timestamp     | start             | see `timeEnd` 		| [odk-instance-first-load](#event:odk-instance-first-load)
 | timestamp     | end               | see `timeEnd`  		| [xforms-revalidate](https://www.w3.org/TR/xforms/#evt-revalidate)
-| property   	| deviceid          | see `deviceID` 	 	| [xforms-ready](https://www.w3.org/TR/xforms/#evt-ready)
-| property		| email             | see `email` 			| [xforms-ready](https://www.w3.org/TR/xforms/#evt-ready)
-| property 		| username          | see `userID` 			| [xforms-ready](https://www.w3.org/TR/xforms/#evt-ready)
-| property      | phone number      | see `phoneNumber`  	| [xforms-ready](https://www.w3.org/TR/xforms/#evt-ready)
-| property      | simserial         | see `simSerial` 		| [xforms-ready](https://www.w3.org/TR/xforms/#evt-ready)
-| property      | subscriberid	    | see `subscriberID`  	| [xforms-ready](https://www.w3.org/TR/xforms/#evt-ready)
+| property   	| deviceid          | see `deviceID` 	 	| [odk-instance-first-load](#event:odk-instance-first-load)
+| property		| email             | see `email` 			| [odk-instance-first-load](#event:odk-instance-first-load)
+| property 		| username          | see `userID` 			| [odk-instance-first-load](#event:odk-instance-first-load)
+| property      | phone number      | see `phoneNumber`  	| [odk-instance-first-load](#event:odk-instance-first-load)
+| property      | simserial         | see `simSerial` 		| [odk-instance-first-load](#event:odk-instance-first-load)
+| property      | subscriberid	    | see `subscriberID`  	| [odk-instance-first-load](#event:odk-instance-first-load)
 
 #### Audit Attributes
 

--- a/_sections/65-events-and-actions.md
+++ b/_sections/65-events-and-actions.md
@@ -6,12 +6,14 @@ XForm Events are dispatched following different steps in the form lifecycle. XFo
 
 ### Events
 
-The following subset of events defined by the [W3C XForms specification](https://www.w3.org/TR/xforms/#rpm-events) are supported:
+See the W3C XForms specification [section on events](https://www.w3.org/TR/xforms/#rpm-events). The following events are supported: 
 
 | event                     | description |
 | --------------------------| ----------- |
-| <a id="event:xforms-ready" href="#event:xforms-ready">`xforms-ready`</a>            | notification event dispatched after all form controls have been initialized. |
-| <a id="event:xforms-value-changed" href="#event:xforms-value-changed">`xforms-value-changed`</a>    | notification event dispatched after an instance data node's value changes. |
+| <a id="event:odk-instance-first-load" href="#event:odk-instance-first-load">`odk-instance-first-load`</a><a id="event:xforms-ready"></a>            | dispatched the first time an instance is loaded |
+| <a id="event:xforms-value-changed" href="#event:xforms-value-changed">`xforms-value-changed`</a>    | dispatched after an instance data node's value changes. |
+
+*Note: `xforms-ready` was previously documented as the event dispatched the first time an instance is loaded. Since that definition does not match the W3C XForms event with the same name, it was deprecated in favor of `odk-instance-first-load`.*
 
 ### Actions
 The following subset of actions defined by the [W3C XForms specification](https://www.w3.org/TR/2003/REC-xforms-20031014/slice10.html#id2634509) are supported:
@@ -26,7 +28,7 @@ Action elements triggered by initialization events go in the model as siblings o
 
 {% highlight xml %}
 <bind nodeset="/data/now" type="dateTime"/>
-<setvalue event="xforms-ready" ref="/data/now" value="now()" />
+<setvalue event="odk-instance-first-load" ref="/data/now" value="now()" />
 {% endhighlight %}
 
 #### Setting a static value when a node's value changes


### PR DESCRIPTION
Closes #223

I'll update the changelog once this is merged but I also thought it was worth adding a quick note inline for a mythical person who knew the spec well a few months ago and then checked back in. I don't feel strongly about it if reviewers would prefer it were removed. I also maintained the `#event:xforms-ready` anchor.