### PR TITLE
Rename Encryption page for consistency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source "https://rubygems.org"
 
 gem 'jekyll'
+gem 'jekyll-redirect-from'
 gem 'kramdown'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,8 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-redirect-from (0.15.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-watch (2.2.1)
@@ -58,6 +60,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
+  jekyll-redirect-from
   kramdown
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -11,3 +11,6 @@ safe: true
 highlighter: rouge
 collections:
 - sections
+
+plugins:
+  - jekyll-redirect-from

--- a/_sections/100-encryption-algorithms.md
+++ b/_sections/100-encryption-algorithms.md
@@ -1,6 +1,7 @@
 ---
-title: Encryption
-page: encryption
+title: Encryption Algorithms
+page: encryption-algorithms
+redirect_from: /encryption/
 ---
 
 ### Introduction

--- a/_sections/91-submission.md
+++ b/_sections/91-submission.md
@@ -53,7 +53,7 @@ Here is an excerpt used in an encryption-enabled XForm:
 <submission base64RsaPublicKey="MIIBIjANB...JCwIDAQAB"/>
 {% endhighlight %}
 
-Full details on the encryption algorithms and submission manifest can be found [here](encryption).
+Full details on the encryption algorithms and submission manifest can be found [here](encryption-algorithms).
 
 
 				

--- a/encryption-algorithms.html
+++ b/encryption-algorithms.html
@@ -11,7 +11,7 @@ layout: default
 <div class="wrap">
     <article class="post-content">
         {% for section in site.sections %}
-        {% if section.page == 'encryption'%}
+        {% if section.page == 'encryption-algorithms'%}
         <section class="post">
             <h2 id="{{section.title | downcase | replace: ' ', '-'}}">{{section.title}}</h2>
             {{ section.output }}

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: default
 <div class="sidenav clearfix">
 	<h4>Sub specs:</h4>
 	<ul class="sub">
-		<li><a href="./encryption">Encryption Algorithms</a></li>
+		<li><a href="./encryption-algorithms">Encryption Algorithms</a></li>
 		<li><a href="./client-audit-logs">Client Audit Logs</a></li>
 	</ul>
 </div>


### PR DESCRIPTION
The link is called Encryption Algorithms but the filename is called encryption. This has caused me great pain.

The pages render great locally, bu I have not been able to get redirects to work. I think they might not work locally in WEBrick?