### PR TITLE
Add odk-new-repeat event

### DIFF
--- a/_sections/65-events-and-actions.md
+++ b/_sections/65-events-and-actions.md
@@ -12,8 +12,39 @@ See the W3C XForms specification [section on events](https://www.w3.org/TR/xform
 | --------------------------| ----------- |
 | <a id="event:odk-instance-first-load" href="#event:odk-instance-first-load">`odk-instance-first-load`</a><a id="event:xforms-ready"></a>            | dispatched the first time an instance is loaded |
 | <a id="event:xforms-value-changed" href="#event:xforms-value-changed">`xforms-value-changed`</a>    | dispatched after an instance data node's value changes. |
+| <a id="event:odk-new-repeat" href="#event:odk-new-repeat">`odk-new-repeat`</a>	| dispatched when a new instance of a repeat is added to the primary instance and before recomputation of `calculates`, etc. Actions triggered by `odk-new-repeat` must be nested in the repeat form control. <a href="#the-odk-new-repeat-event">See more</a>.
 
 *Note: `xforms-ready` was previously documented as the event dispatched the first time an instance is loaded. Since that definition does not match the W3C XForms event with the same name, it was deprecated in favor of `odk-instance-first-load`.*
+
+#### The `odk-new-repeat` event
+The `odk-new-repeat` event is dispatched when a new instance of a repeat is added to the primary instance and before recomputation of `calculates`, `constraints`, etc. Actions triggered by `odk-new-repeat` must be nested in the repeat form control.
+
+Unlike <a href="https://www.w3.org/TR/xforms/#evt-insert">W3C XForms' `xforms-insert`</a>:
+<ul>
+	<li>it is narrowly for repeats (ODK XForms currently has no notion of inserting arbitrary nodes)</li>
+	<li>its handlers must be nested in the corresponding repeat control (W3C XForms identifies the added nodes and the insert position in event context information so handlers can go anywhere)</li>
+	<li>it is dispatched separately for each repeat instance (in W3C XForms, a single insert action may insert multiple nodes)</li>
+</ul>
+
+The `odk-new-repeat` event is never dispatched for repeat instances that are part of the form definition. However, it is dispatched for repeat instances added by evaluation of the `jr:count` attribute value. See <a href="#creation-removal-of-repeats">creation, removal of repeats</a>.
+
+The following example demonstrates giving a node in a repeat a default, user-modifiable value based on other user input:
+
+{% highlight xml %}
+<h:body>
+    <input ref="/data/my_age">
+        <label>Your age</label>
+    </input>
+    ...
+    <repeat nodeset="/data/person">
+        <setvalue event="odk-new-repeat" ref="/data/person/age" value="../../my_age + 2" />
+        <input ref="/data/person/age">
+            <label>Person's age</label>
+        </input>
+        ...
+    </repeat>
+</h:body>
+{% endhighlight %}
 
 ### Actions
 The following subset of actions defined by the [W3C XForms specification](https://www.w3.org/TR/2003/REC-xforms-20031014/slice10.html#id2634509) are supported:
@@ -23,7 +54,7 @@ The following subset of actions defined by the [W3C XForms specification](https:
 | <a id="action:setvalue" href="#action:setvalue">`setvalue`</a>  | Explicitly sets the value of the specified instance data node. See [the W3C description](https://www.w3.org/TR/2003/REC-xforms-20031014/slice10.html#action-setvalue). `ref` can be used in place of `bind` to specify a node path instead of a node id. |
 | <a id="action:setgeopoint" href="#action:setgeopoint">`odk:setgeopoint`</a>  | Sets the current location's [geopoint](#data-types) value in the instance data node specified in the `ref` attribute. Any `value` attribute or textContent will be ignored. Failure to retrieve the location will result in an empty string value. |
 
-Action elements triggered by initialization events go in the model as siblings of `bind` nodes. Action elements triggered by control-specific events are nested in that control block. 
+Action elements triggered by initialization events go in the model as siblings of `bind` nodes. Action elements triggered by control-specific events are nested in that control block. Multiple triggering events may be specified as a space-separated list and in that case, initialization events may be specified in an action element nested in a control block. For example, the value `odk-instance-first-load odk-new-repeat` can be given to the `event` attribute of an action nested in a repeat. That action is then triggered once the first time the primary instance is loaded and every time an instance of the parent repeat is added.
 
 #### Setting a dynamic value after form load
 

--- a/_sections/65-events-and-actions.md
+++ b/_sections/65-events-and-actions.md
@@ -12,19 +12,12 @@ See the W3C XForms specification [section on events](https://www.w3.org/TR/xform
 | --------------------------| ----------- |
 | <a id="event:odk-instance-first-load" href="#event:odk-instance-first-load">`odk-instance-first-load`</a><a id="event:xforms-ready"></a>            | dispatched the first time an instance is loaded |
 | <a id="event:xforms-value-changed" href="#event:xforms-value-changed">`xforms-value-changed`</a>    | dispatched after an instance data node's value changes. |
-| <a id="event:odk-new-repeat" href="#event:odk-new-repeat">`odk-new-repeat`</a>	| dispatched when a new instance of a repeat is added to the primary instance and before recomputation of `calculates`, etc. Actions triggered by `odk-new-repeat` must be nested in the repeat form control. <a href="#the-odk-new-repeat-event">See more</a>.
+| <a id="event:odk-new-repeat" href="#event:odk-new-repeat">`odk-new-repeat`</a>	| dispatched when a new instance of a repeat is added to the primary instance. <a href="#the-odk-new-repeat-event">See more</a>.
 
 *Note: `xforms-ready` was previously documented as the event dispatched the first time an instance is loaded. Since that definition does not match the W3C XForms event with the same name, it was deprecated in favor of `odk-instance-first-load`.*
 
-#### The `odk-new-repeat` event
+#### The odk-new-repeat event
 The `odk-new-repeat` event is dispatched when a new instance of a repeat is added to the primary instance and before recomputation of `calculates`, `constraints`, etc. Actions triggered by `odk-new-repeat` must be nested in the repeat form control.
-
-Unlike <a href="https://www.w3.org/TR/xforms/#evt-insert">W3C XForms' `xforms-insert`</a>:
-<ul>
-	<li>it is narrowly for repeats (ODK XForms currently has no notion of inserting arbitrary nodes)</li>
-	<li>its handlers must be nested in the corresponding repeat control (W3C XForms identifies the added nodes and the insert position in event context information so handlers can go anywhere)</li>
-	<li>it is dispatched separately for each repeat instance (in W3C XForms, a single insert action may insert multiple nodes)</li>
-</ul>
 
 The `odk-new-repeat` event is never dispatched for repeat instances that are part of the form definition. However, it is dispatched for repeat instances added by evaluation of the `jr:count` attribute value. See <a href="#creation-removal-of-repeats">creation, removal of repeats</a>.
 


### PR DESCRIPTION
Closes #246 

Based on the conversation at https://forum.opendatakit.org/t/xforms-spec-proposal-add-event-fired-when-new-repeat-instance-is-created/19616

Please let me know if it's feeling like too much detail. I tried to capture everything we discussed and leave as little ambiguity as possible. In particular, the contrasting with W3C XForms feels like useful context to me but it's not really necessary.

The example is not realistic -- why in the world would 2 above the user's age be a useful default? My goal is to show an expression and the evaluation context for `value`. If a reviewer thinks a more realistic example would help, I can think of something.

CC @tiritea