### PR TITLE
Improve readability on mobile devices/small viewports

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <meta name="description" content="{{ site.description }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 

--- a/css/main.css
+++ b/css/main.css
@@ -234,7 +234,8 @@ table tr th, table tr td {
 /* ----------------------------------------------------------*/
 
 .page-content {
-    padding: 30px;
+    --page-padding: clamp(16px, 3vw, 30px);
+    padding: var(--page-padding);
     background-color: #fff;
 }
 
@@ -349,6 +350,10 @@ table tr th, table tr td {
     padding: 1px 5px;
 }
 
+.post p code {
+    word-wrap: break-word;
+}
+
 .post ul,
 .post ol {
     margin-left: 1.35em;
@@ -389,6 +394,14 @@ table tr th, table tr td {
     cursor: pointer;
     text-decoration: underline;
 }
+
+.table-wrapper {
+    max-width: calc(100% + var(--page-padding));
+    margin-right: calc(0px - var(--page-padding));
+    padding-right: var(--page-padding);
+    overflow-x: auto;
+}
+
 
 /* Syntax highlighting styles */
 /* ----------------------------------------------------------*/
@@ -744,7 +757,7 @@ table tr th, table tr td {
 
 @media screen and (max-width: 600px) {
     .wrap {
-        padding: 0 12px;
+        padding: 0;
     }
 
     .site-nav {

--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     addNavMenu();
     setHeaderListeners();
+    wrapTables();
 });
 
 /**
@@ -100,3 +101,17 @@ function addClickableClass(elements) {
         }
     }
 }
+
+const wrapTables = () => {
+    const tables = document.querySelectorAll('table');
+    const wrapperTemplate = document.createElement('div');
+
+    wrapperTemplate.classList.add('table-wrapper');
+
+    for (const table of tables) {
+        const wrapper = wrapperTemplate.cloneNode();
+
+        table.after(wrapper);
+        wrapper.appendChild(table);
+    }
+};


### PR DESCRIPTION
- Sets initial page zoom to 1, which is a sensible default for mobile browsers
- Prevents horizontal scrolling of the page by allowing long inline `code` elements to wrap, and wrapping tables in their own scrollable blocks (not dissimilar to the already scrollable code blocks)