### PR TITLE
Document `base64-decode` and process for adding functions

### DIFF
--- a/_sections/15-namespaces.md
+++ b/_sections/15-namespaces.md
@@ -4,8 +4,8 @@ title: Namespaces
 
 XML namespaces provide a way to avoid name conflicts for element and attribute names. In ODK XForms, the elements and attributes that are also in XForms 1.0 are in the [XForms namespace](https://www.w3.org/TR/xforms/#structure-namespace) which is declared as the default namespace in the example above (`xmlns="http://www.w3.org/2002/xforms"`). Setting a default namespace means that non-prefixed elements and attributes are assigned that namespace.
 
-Elements and attributes that are specific to ODK XForms and not defined by the XForms 1.0 specification should be separately namespaced. For historical reasons, the `"http://openrosa.org/javarosa"` namespace (with the `jr` prefix in this document), and the `"http://openrosa.org/xforms"` namespace (with the `orx` prefix in this document) have been used.
+Elements and attributes that are specific to ODK XForms and not defined by the XForms 1.0 specification should be separately namespaced. For historical reasons, the `"http://openrosa.org/javarosa"` namespace (with the `jr` prefix in this document), and the `"http://openrosa.org/xforms"` namespace (with the `orx` prefix in this document) have been used. For any new additions not defined in another specification, the `"http://www.opendatakit.org/xforms"` namespace is now preferred. It is assigned the `odk` prefix in this documentation. If a new feature is copied from another XForms implementation the originator's namespace will be used.
 
-For any new additions not defined in another specification, the `"http://www.opendatakit.org/xforms"` namespace is now preferred. It is assigned the `odk` prefix in this documentation. If a new feature is copied from another XForms implementation the originator's namespace will be used.
+[XPath functions](#xpath-functions) are generally introduced in the default namespace. This convention makes it easier for end-users to use those functions: they are usually directly exposed from form designers.
 
 For more information about namespaces, see the [XML Namespaces specification](http://www.w3.org/TR/REC-xml-names/).

--- a/_sections/30-bindings.md
+++ b/_sections/30-bindings.md
@@ -193,6 +193,7 @@ For convenience, the functions are categorized based on their main usage. Some f
 <a id="fn:Geographic-Functions" href="#fn:Geographic-Functions">**Geographic Functions**</a>|||
 <a id="fn:area" href="#fn:area">`area(node-set ns|geoshape gs)`</a> | number | Returns the calculated area in m2 of either a node-set of geopoints or a geoshape value (not a combination of both) on Earth. It takes into account the circumference of the Earth around the Equator but does not take altitude into account.
 <a id="fn:distance" href="#fn:distance">`distance(node-set ns|geoshape gs|geotrace gt)`</a> |  number | Returns the distance in meters of either a node-set of geopoints or a single geoshape value or a single geotrace value (not a combination of these) on Earth, in the sequence provided by the points in the parameter. It takes into account the circumference of the Earth around the Equator and does not take altitude into account.
+<a id="fn:base64-decode" href="#fn:base64-decode">`base64-decode(base64Binary input)`| `string` | Interprets the contents of the base64Binary value as a sequence of bytes representing a UTF-8 character string and returns the corresponding string.
 
 ### Metadata
 


### PR DESCRIPTION
Documents `base64-decode` as implemented at https://github.com/getodk/javarosa/blob/203f37b702e0c5aadff45d2f7bc7010875328a5f/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java#L1260

<details>
<summary>Original proposal</summary>
Opening this PR for discussion around two proposed function additions.

I propose adding these in the default/XForm namespace as other custom functions have been introduced in the past. For better or worse, the ODK ecosystem doesn't use namespacing consistently and is not generally compatible with arbitrary XForms. If we do namespace new functions, we either have to expose that to end users of XLSForm or have XLSForm detect namespaced functions and inject namespacing information.

The last commit in this PR describes this approach to function namespacing.

`centroid` is based on http://expath.org/spec/geo#d2e981 but with ODK types.

`base64Binary-to-string` is based on https://www.saxonica.com/html/documentation10/functions/saxon/base64Binary-to-string.html for its simplicity.

Additional candidates:
- http://expath.org/spec/binary#decode-string has more complexity than we need
- https://synapse.apache.org/userguide/xpath.html#base64_decode is similar but the Saxonica function better matches our naming conventions
</details>