### PR TITLE
Remove example with descendant-or-self (//) axis

### DIFF
--- a/_sections/30-bindings.md
+++ b/_sections/30-bindings.md
@@ -81,7 +81,6 @@ The following are examples of valid paths:
 * `../relative/path/to/node`
 * `./relative/path/to/node`
 * `another/relative/path`
-* `//node`
 
 ### XPath Operators
 


### PR DESCRIPTION
The section on axes says: "only the _parent_, _child_ and _self_ axes are supported"

// is supported by the JR parser but not the evaluator. It's presumably supported by Enketo through the browser implementation. It's not all that helpful when writing forms because deep nesting is not common and where it might be useful (e.g. nested repeats), it's not good performance-wise.