### PR TITLE
Clarify that repeat naming group must be first child

### DIFF
--- a/_sections/60-repeats.md
+++ b/_sections/60-repeats.md
@@ -43,7 +43,7 @@ A `<repeat>` cannot have a label child element. To display a label it should be 
 ...
 {% endhighlight %}
 
-When a client needs to compactly show a single repeat instance in its user interface (e.g. as a collapsed repeat or a table-of-contents item), it is recommended to show the label of the first child group of that repeat.
+When a client needs to compactly show a single repeat instance in its user interface (e.g. as a collapsed repeat or a table-of-contents item), it is recommended to show the label of the first child of that repeat if that first child is a group.
 
 ### Creation, Removal of Repeats
 


### PR DESCRIPTION
The current wording implies that if you have the following structure:

```
repeat
    question
    group
```

the label of that group would be used as the label for repeat instances. I don't believe that was ever the intent. In both Collect and Enketo, a group label is only used as an repeat instance label if it is the first child of that repeat. That's also how it's documented in the ODK docs: https://docs.getodk.org/form-logic/#naming-repeats-to-help-with-navigation