### PR TITLE
Fix use of baseVersion that should have been __version in entities spec

### DIFF
--- a/_sections/120-entities.md
+++ b/_sections/120-entities.md
@@ -160,8 +160,8 @@ Entity updates are declared in the `entity` element in the [`meta` block](./#met
 - MAY have a direct child label representing a human-readable label
 
 When a consumer of this specification applies an entity `update`, it:
-- MUST treat a `baseVersion` value other than a positive integer as 0
-- MUST increment the `baseVersion` of its local entity representation by 1 when an update is successfully applied
+- MUST treat a `__version` value other than a positive integer, including a missing value, as 0
+- MUST increment the `__version` of its local entity representation by 1 when an update is successfully applied
 
 ### Identifying entity properties
 


### PR DESCRIPTION
This section describes what will be written to the `baseVersion` attribute but it's really about `__version` which is what spec consumers keep as local state that gets queried by the form.