### PR TITLE
chore: updates geopoint documentation

### DIFF
--- a/_sections/40-body.md
+++ b/_sections/40-body.md
@@ -79,8 +79,8 @@ The following attributes are supported on body elements. Note that most attribut
 | `jr:count`      | For the `<repeat>` element (see [repeats](#repeats)). This is one of the ways to specify how many repeats should be created by default.
 | `jr:noAddRemove`| For the `<repeat>` element (see [repeats](#repeats)). This indicates whether the user is allowed to add or remove repeats. Can have values `true()` and `false()`
 | `autoplay`      | For all form control elements, this automatically plays a [video or audio 'label'](#media) if the question is displayed on its own page, when the user reaches this page.
-| `accuracyThreshold` | For `<input>` with type `geopoint`, `geotrace`, or `geoshape`. Sets the auto-accept threshold in meters (decimals) for geopoint captures.
-| `unacceptableAccuracyThreshold` | For `<input>` with type `geopoint`, `geotrace`, or `geoshape`. Sets the threshold for unacceptable accuracy, in meters (decimals), for geopoint captures.
+| `accuracyThreshold` | For `<input>` with type `geopoint`. Sets the auto-accept threshold in meters (decimals) for geopoint captures.
+| `unacceptableAccuracyThreshold` | For `<input>` with type `geopoint`. Sets the threshold for unacceptable accuracy, in meters (decimals), for geopoint captures.
 | `value`         | For the `<output>` element to reference the node value to be displayed.
 | `rows`          | Specifies the minimum number of rows a string `<input>` field gets.
 | `mediatype`     | For the `<upload>` element. The string value specifies the kind of media picker that will be displayed. Unlike in XForms 1.0, only one value can be specified. Possible values vary by client and examples include `image/*`, `audio/*` and `video/*`. Ignored if `accept` is also specified.

--- a/_sections/40-body.md
+++ b/_sections/40-body.md
@@ -79,7 +79,7 @@ The following attributes are supported on body elements. Note that most attribut
 | `jr:count`      | For the `<repeat>` element (see [repeats](#repeats)). This is one of the ways to specify how many repeats should be created by default.
 | `jr:noAddRemove`| For the `<repeat>` element (see [repeats](#repeats)). This indicates whether the user is allowed to add or remove repeats. Can have values `true()` and `false()`
 | `autoplay`      | For all form control elements, this automatically plays a [video or audio 'label'](#media) if the question is displayed on its own page, when the user reaches this page.
-| `accuracyThreshold` | For `<input>` with type `geopoint`, `geotrace`, or `geoshape` this sets the auto-accept threshold in meters for geopoint captures. [review]()
+| `accuracyThreshold` | For `<input>` with type `geopoint`, `geotrace`, or `geoshape` this sets the auto-accept threshold in meters for geopoint captures.
 | `value`         | For the `<output>` element to reference the node value to be displayed.
 | `rows`          | Specifies the minimum number of rows a string `<input>` field gets.
 | `mediatype`     | For the `<upload>` element. The string value specifies the kind of media picker that will be displayed. Unlike in XForms 1.0, only one value can be specified. Possible values vary by client and examples include `image/*`, `audio/*` and `video/*`. Ignored if `accept` is also specified.

--- a/_sections/40-body.md
+++ b/_sections/40-body.md
@@ -79,7 +79,8 @@ The following attributes are supported on body elements. Note that most attribut
 | `jr:count`      | For the `<repeat>` element (see [repeats](#repeats)). This is one of the ways to specify how many repeats should be created by default.
 | `jr:noAddRemove`| For the `<repeat>` element (see [repeats](#repeats)). This indicates whether the user is allowed to add or remove repeats. Can have values `true()` and `false()`
 | `autoplay`      | For all form control elements, this automatically plays a [video or audio 'label'](#media) if the question is displayed on its own page, when the user reaches this page.
-| `accuracyThreshold` | For `<input>` with type `geopoint`, `geotrace`, or `geoshape` this sets the auto-accept threshold in meters for geopoint captures.
+| `accuracyThreshold` | For `<input>` with type `geopoint`, `geotrace`, or `geoshape`. Sets the auto-accept threshold in meters (decimals) for geopoint captures.
+| `unacceptableAccuracyThreshold` | For `<input>` with type `geopoint`, `geotrace`, or `geoshape`. Sets the threshold for unacceptable accuracy, in meters (decimals), for geopoint captures.
 | `value`         | For the `<output>` element to reference the node value to be displayed.
 | `rows`          | Specifies the minimum number of rows a string `<input>` field gets.
 | `mediatype`     | For the `<upload>` element. The string value specifies the kind of media picker that will be displayed. Unlike in XForms 1.0, only one value can be specified. Possible values vary by client and examples include `image/*`, `audio/*` and `video/*`. Ignored if `accept` is also specified.


### PR DESCRIPTION
### Description

- Removes distracting link ("review") that takes to nowhere - I got a bit lost when clicking on that and wondering where to read
- Adds documentation for `unacceptableAccuracyThreshold` attribute

Closes https://github.com/getodk/xforms-spec/issues/290