### PR TITLE
chore: fix mistake in the phonenumber preload param

### DIFF
--- a/_sections/30-bindings.md
+++ b/_sections/30-bindings.md
@@ -249,13 +249,13 @@ Supported preload attribute combinations are:
 | jr:preload    | jr:preloadParams  | value           		| event
 |---------------|-------------------|-----------------------|-------------
 | uid           |                   | see `instanceID` 		| [odk-instance-first-load](#event:odk-instance-first-load)
-| timestamp     | start             | see `timeEnd` 		| [odk-instance-first-load](#event:odk-instance-first-load)
+| timestamp     | start             | see `timeStart` 		| [odk-instance-first-load](#event:odk-instance-first-load)
 | timestamp     | end               | see `timeEnd`  		| [xforms-revalidate](https://www.w3.org/TR/xforms/#evt-revalidate)
 | date          | today             | see `today`           | [odk-instance-first-load](#event:odk-instance-first-load)
 | property   	| deviceid          | see `deviceID` 	 	| [odk-instance-first-load](#event:odk-instance-first-load)
 | property		| email             | see `email` 			| [odk-instance-first-load](#event:odk-instance-first-load)
 | property 		| username          | see `userID` 			| [odk-instance-first-load](#event:odk-instance-first-load)
-| property      | phone number      | see `phoneNumber`  	| [odk-instance-first-load](#event:odk-instance-first-load)
+| property      | phonenumber       | see `phoneNumber`  	| [odk-instance-first-load](#event:odk-instance-first-load)
 
 #### Audit Attributes
 

--- a/_sections/30-bindings.md
+++ b/_sections/30-bindings.md
@@ -214,7 +214,7 @@ The namespace of the meta block is either the default XForms namespace or "https
             <orx:userID/>
             <orx:instanceID/>
             <orx:instanceName/>
-            <orx:audit/>>
+            <orx:audit/>
         </orx:meta>
     </data>
 </instance>


### PR DESCRIPTION
This matches the implementation in [Collect](https://github.com/getodk/collect/blob/60d58edd64d72d0e2247f163cb504ba238288552/metadata/src/main/java/org/odk/collect/metadata/PropertyManager.kt#L31) and [enketo](https://github.com/enketo/enketo/blob/e6a7e3eb68d5f7584885ef42ff3b628b614ce9aa/packages/enketo-core/src/js/form-model.js#L266)