### PR TITLE
Clarify entity form processing when both `create` and `update` are true

### DIFF
--- a/_sections/120-entities.md
+++ b/_sections/120-entities.md
@@ -169,7 +169,7 @@ Entity updates are declared in the `entity` element in the [`meta` block](./#met
 - MUST have a `update` attribute populated with a "1" or "true" if the entity should be updated
   - Consumers of submissions that update entities MUST interpret "1" or "true" as indications to update an entity and any other value as indication not to update an entity
 - MUST have a `baseVersion` attribute that is populated with the version of the entity that the form had access to
-- MAY also have a bind to a `create` attribute as previously defined. In that case, the form designer is responsible for making sure that the id is correctly populated in each case and that the `update` and `create` conditions don't result in both being truthy at the same time. If both are truthy, the spec consumer processing submissions should do both and one of them will fail.
+- MAY also have a bind to a `create` attribute as previously defined. In that case, the form designer is responsible for making sure that the id is correctly populated in each case and that the `update` and `create` conditions don't result in both being truthy at the same time. If both are truthy, how the spec consumer should process the submission is determined by whether entity already exists or not: it should be created if it does not exist (as identified by the entity_id expression), and updated if it does.
 - MAY have a direct child label representing a human-readable label. If it is absent or blank, the update has no effect on the Entity's label
 
 


### PR DESCRIPTION
This should make it clearer what the intention is in this scenario.