### PR TITLE
gitignore: ignore jekyll temp file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ _site
 
 # RubyMine IDE files.
 .idea/
+
+/.jekyll-metadata


### PR DESCRIPTION
This file seems to be generated when running the site locally, per the README instructions.