### PR TITLE
Gemfile: specify ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source "https://rubygems.org"
 
+ruby '3.1'
+
 gem 'jekyll'
 gem 'kramdown'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby '3.1'
+ruby '~> 3.1.0'
 
 gem 'jekyll'
 gem 'kramdown'


### PR DESCRIPTION
It seems like some dependencies require Ruby v3.1.  Setting this in the `Gemfile` should help future devs to get their environment set up more easily.

Ref #356